### PR TITLE
TSet exemplar tests fix

### DIFF
--- a/test/exemplar.jl
+++ b/test/exemplar.jl
@@ -69,7 +69,7 @@ map_nested = Dict{Any,Any}(:simple => map_simple, :mixed => map_mixed)
 
 vector_simple  = Any[1, 2, 3]
 
-vector_mixed  = Any[0, 1, 2.0, true, false, "five", :six, TSymbol(:seven), "~eight", nothing]
+vector_mixed  = Any[0, 1, 2.0, true, false, UTF8String("five"), :six, TSymbol(:seven), UTF8String("~eight"), nothing]
 
 vector_nested = Any[vector_simple, vector_mixed]
 


### PR DESCRIPTION
At least on Julia 0.4.5, UTF8String set members do not compare/has as equal in the TSet member dict. Documenting and applying test fix while investigating issue #3 so that the corresponding change passes tests. Other work to be done for testing on later versions of Julia, not sure if behavior of string literals re: type encoding and if that type affects hashing or equality in sets and dictionaries yet.

Note: 0.4.5 is still the system Julia you get on Ubuntu 16.04 (current LTS build), this and other PR will wrap up the reported issue for that version (indicating a minor release) before we test version increments to 0.5 then 0.6.