### PR TITLE
Julia v0.6 port

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.4.3
-JSON 0.5.0
-URIParser 0.0.5
+julia 0.6.0
+JSON 0.13.0
+URIParser 0.1.8
 Decimals 0.1.0
-DataStructures 0.4.4
+DataStructures 0.6.0

--- a/src/Transit.jl
+++ b/src/Transit.jl
@@ -1,25 +1,27 @@
 module Transit
-  import JSON
-  import Base.getindex
-  import Base
 
-  using DataStructures
-  using URIParser
-  using Decimals
+import JSON
+import Base.getindex
+import Base
 
-  export Encoder, encode, parse, decode
+using DataStructures
+using URIParser
+using Decimals
 
-  include("tagged_value.jl")
-  include("tsymbol.jl")
-  include("tset.jl")
-  include("turi.jl")
-  include("link.jl")
-  include("constants.jl")
-  include("cache.jl")
-  include("decoder.jl")
-  include("utilities.jl")
-  include("emitter.jl")
-  include("encoder.jl")
-  include("writer.jl")
-  include("reader.jl")
+export parse, write
+
+include("tagged_value.jl")
+include("tsymbol.jl")
+include("tset.jl")
+include("turi.jl")
+include("link.jl")
+include("constants.jl")
+include("cache.jl")
+include("decoder.jl")
+include("utilities.jl")
+include("emitter.jl")
+include("encoder.jl")
+include("writer.jl")
+include("reader.jl")
+
 end

--- a/src/Transit.jl
+++ b/src/Transit.jl
@@ -8,7 +8,8 @@ using DataStructures
 using URIParser
 using Decimals
 
-export parse, write
+export parse, write,  # intended public use
+       Decoder, Encoder, decode, encode  # used by tests
 
 include("tagged_value.jl")
 include("tsymbol.jl")

--- a/src/cache.jl
+++ b/src/cache.jl
@@ -1,7 +1,8 @@
-abstract Cache
+abstract type Cache
+end
 
 # Do nothing cache used in verbose mode.
-type NoopCache <: Cache
+mutable struct NoopCache <: Cache
 end
 
 function write!(rc::NoopCache, name::AbstractString)
@@ -9,11 +10,11 @@ function write!(rc::NoopCache, name::AbstractString)
 end
 
 # Real caching.
-type RollingCache <: Cache
-    key_to_value::Dict{ASCIIString,Any}
-    value_to_key::Dict{Any,ASCIIString}
+mutable struct RollingCache <: Cache
+    key_to_value::Dict{AbstractString,Any}
+    value_to_key::Dict{Any,AbstractString}
 
-    RollingCache() = new(Dict{ASCIIString,Any}(), Dict{Any,ASCIIString}())
+    RollingCache() = new(Dict{AbstractString,Any}(), Dict{Any,AbstractString}())
 end
 
 const FIRST_ORD = 48

--- a/src/decoder.jl
+++ b/src/decoder.jl
@@ -1,9 +1,9 @@
-type Decoder
-    decoderFunctions
+mutable struct Decoder
+    decoderFunctions::Dict{AbstractString,Function}
 
-    Decoder() = new(Dict{ASCIIString,Function}(
+    Decoder() = new(Dict{AbstractString,Function}(
                         "_"  => (x -> nothing),
-                        ":"  => symbol,
+                        ":"  => (x -> Symbol(x)),
                         "\$" => (x -> TSymbol(x)),
                         "?"  => (x -> x == "t"),
                         "b"  => base64decode,
@@ -32,8 +32,7 @@ type Decoder
                         "link" => (x -> Link(x...)),
                         "list" => tolist,
                         "ratio" => (x -> x[1]//x[2]),
-                        "cmap" => (x -> [a[1] => a[2]
-                                         for a in zip(x[1:2:end], x[2:2:end])])
+                        "cmap" => (x -> Dict{Any, Any}(a[1] => a[2] for a in zip(x[1:2:end], x[2:2:end])))
                     ))
 end
 

--- a/src/emitter.jl
+++ b/src/emitter.jl
@@ -1,6 +1,6 @@
   import JSON
 
-  type Emitter
+  mutable struct Emitter
     io::IO
     cache::Cache
   end

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -1,4 +1,4 @@
-type Encoder
+mutable struct Encoder
     verbose::Bool
     encoder_functions
     encodes_to_string
@@ -50,7 +50,7 @@ function encode_top_level(e::Encoder, x::Any)
     if encodes_to_string(e, x)
         encode_quoted(e, x)
     else
-        encode(e, x, false) 
+        encode(e, x, false)
     end
 end
 
@@ -178,7 +178,7 @@ function encode_tagged_enumerable(e::Encoder, tag::AbstractString, iter)
     emit_array_sep(e.emitter)
 
     emit_array_start(e.emitter)
-    encode_iterator(e, iter) 
+    encode_iterator(e, iter)
     emit_array_end(e.emitter)
     emit_array_end(e.emitter)
 end

--- a/src/link.jl
+++ b/src/link.jl
@@ -1,4 +1,4 @@
-type Link
+struct Link
     href::URI
     rel::AbstractString
     name::AbstractString

--- a/src/noop_cache.jl
+++ b/src/noop_cache.jl
@@ -1,4 +1,4 @@
-type NoopCache
+mutable struct NoopCache
 end
 
 function write!(rc::RollingCache, name::AbstractString)

--- a/src/tagged_value.jl
+++ b/src/tagged_value.jl
@@ -1,8 +1,8 @@
-immutable Tag
+struct Tag
     rep::AbstractString
 end
 
-type TaggedValue
+mutable struct TaggedValue
     tag::AbstractString
     value::Any
 end
@@ -17,8 +17,8 @@ const hashttaggedvalue_seed = UInt === UInt64 ? 0x8ee14727cfcae1ce : 0x1f487ece
 
 function hash(tv::TaggedValue, h::UInt)
     h = hash(hashttaggedvalue_seed, h)
-    h $= hash(tv.tag)
-    h $= hash(tv.value)
+    h ⊻= hash(tv.tag)
+    h ⊻= hash(tv.value)
     return h
 end
 

--- a/src/tset.jl
+++ b/src/tset.jl
@@ -12,11 +12,11 @@ import Base.print
 import Base.println
 
 
-immutable TSet
-    dict::Dict{Tuple{Any,DataType},Any}
+struct TSet
+    dict #::Dict{Tuple{Any,DataType},Any}
 
     TSet() = new(Dict{Tuple{Any,DataType},Any}())
-    TSet(itr) = new([(x, typeof(x)) => x for x in itr])
+    TSet(itr) = new(Dict((x, typeof(x)) => x for x in itr))
 end
 
 in(x, s::TSet) = haskey(s.dict, (x, typeof(x)))
@@ -39,7 +39,7 @@ const hashtset_seed = UInt === UInt64 ? 0x852ada37cfe8e0ce : 0xcfe8e0ce
 function hash(s::TSet, h::UInt)
     h = hash(hashtset_seed, h)
     for x in s
-        h $= hash(x)
+        h ⊻= hash(x)
     end
     return h
 end

--- a/src/tset.jl
+++ b/src/tset.jl
@@ -13,7 +13,7 @@ import Base.println
 
 
 struct TSet
-    dict #::Dict{Tuple{Any,DataType},Any}
+    dict
 
     TSet() = new(Dict{Tuple{Any,DataType},Any}())
     TSet(itr) = new(Dict((x, typeof(x)) => x for x in itr))

--- a/src/tsymbol.jl
+++ b/src/tsymbol.jl
@@ -1,4 +1,4 @@
-immutable TSymbol
+struct TSymbol
   s::AbstractString
 
   TSymbol(x) = new(string(x))
@@ -14,7 +14,7 @@ const hashtsymbol_seed = UInt === UInt64 ? 0x8ee11137cfaae3ce : 0x2f28e1ce
 
 function hash(ts::TSymbol, h::UInt)
     h = hash(hashtsymbol_seed, h)
-    h $= hash(ts.s)
+    h ⊻= hash(ts.s)
     return h
 end
 

--- a/src/turi.jl
+++ b/src/turi.jl
@@ -1,4 +1,4 @@
-type TURI
+struct TURI
     value::AbstractString
 end
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -22,7 +22,7 @@ function tolist(a::AbstractArray)
 end
 
 
-date_formats = ["yyyy-mm-ddTHH:MM:SS.sss", "yyyy-mm-ddTHH:MM:SS"]
+date_formats = ("yyyy-mm-ddTHH:MM:SS.sss", "yyyy-mm-ddTHH:MM:SS")
 
 function parsedatetime(s::AbstractString)
     s = replace(s, r"Z$", "")

--- a/test/decoder.jl
+++ b/test/decoder.jl
@@ -1,7 +1,10 @@
 include("../src/Transit.jl")
+module TestDecoder
 
 using Base.Test
-import Transit
+using Transit
+using JSON
+using Decimals
 
 function square_trip(inval)
   io = IOBuffer()
@@ -9,7 +12,6 @@ function square_trip(inval)
   seek(io, 0)
   Transit.parse(io)
 end
-
 
 @test square_trip(["~~foo"]) == ["~foo"]
 @test square_trip(["~#'","~~foo"]) == "~foo"
@@ -19,7 +21,7 @@ end
 
 @test square_trip([1, 2, 3, 4]) == [1, 2, 3, 4]
 @test square_trip(["some", "funny", "words"]) == ["some", "funny", "words"]
-@test square_trip([1, "and", 2, "we", Dict{Any,Any}("mix"=>"it up")]) == 
+@test square_trip([1, "and", 2, "we", Dict{Any,Any}("mix"=>"it up")]) ==
                  [1, "and", 2, "we", Dict{Any,Any}("mix"=>"it up")]
 @test square_trip(Dict{Any,Any}("a" => 1, "b" => 2)) == Dict{Any,Any}("a" => 1, "b" => 2)
 @test square_trip(Dict{Any,Any}("a" => 1)) == Dict{Any,Any}("a" => 1)
@@ -40,3 +42,5 @@ end
 # fix for URI change
 #@test square_trip(Any["~rhttp://example.com","~rftp://example.com"]) == Any[URIParser.URI("http://example.com"), URIParser.URI("ftp://example.com")]
 #@test square_trip(["~m-6106017600000","~m0","~m946728000000","~m1396909037000"]) == TBD - what do you typically want?
+
+end

--- a/test/exemplar.jl
+++ b/test/exemplar.jl
@@ -2,13 +2,16 @@ include("../src/Transit.jl")
 module TestTransit
 
 using Base.Test
-using DataStructures  
+using DataStructures
 
 import JSON
 import Transit
 import Transit.TSymbol
 import Transit.TSet
 import Transit.TaggedValue
+
+import Base.Iterators.take
+import Base.Iterators.cycle
 
 
 function range_centered_on(n)
@@ -44,13 +47,7 @@ function dict_of(a...)
   keys = a[1:2:length(a)]
   vals = a[2:2:length(a)]
 
-  result = Dict{Any,Any}()
-
-  for i in 1:length(keys)
-    result[keys[i]] = vals[i]
-  end
-
-  result
+  Dict{Any,Any}(zip(keys, vals))
 end
 
 function nested_dict(n)
@@ -60,7 +57,7 @@ end
 function nested_dict_exemplar(n)
     Exemplar("map_$(n)_nested", "Map of two nested $n maps", nested_dict(n))
 end
- 
+
 map_simple = Dict{Any,Any}(:a => 1, :b => 2, :c => 3)
 
 map_mixed = Dict{Any,Any}(:a => 1, :b => "a string", :c => true)
@@ -69,7 +66,7 @@ map_nested = Dict{Any,Any}(:simple => map_simple, :mixed => map_mixed)
 
 vector_simple  = Any[1, 2, 3]
 
-vector_mixed  = Any[0, 1, 2.0, true, false, UTF8String("five"), :six, TSymbol(:seven), UTF8String("~eight"), nothing]
+vector_mixed  = Any[0, 1, 2.0, true, false, "five", :six, TSymbol(:seven), "~eight", nothing]
 
 vector_nested = Any[vector_simple, vector_mixed]
 
@@ -134,7 +131,7 @@ exemplars = [
 
     Exemplar( "small_strings", "A vector of small strings", small_strings),
 
-    Exemplar( "strings_tilde", "A vector of strings starting with ~", 
+    Exemplar( "strings_tilde", "A vector of strings starting with ~",
 	      map(x -> "~$x", small_strings)),
 
     Exemplar( "strings_hash", "A vector of strings starting with #",
@@ -180,7 +177,7 @@ exemplars = [
 
     Exemplar( "list_simple", "A simple list", list_of(vector_simple)),
     Exemplar( "list_empty", "An empty list", list()),
-    Exemplar( "list_mixed", "A ten element list with mixed values", 
+    Exemplar( "list_mixed", "A ten element list with mixed values",
 	      list_of(vector_mixed)),
 
     Exemplar( "list_nested", "Two lists nested inside an outter list",
@@ -196,7 +193,7 @@ exemplars = [
     Exemplar( "map_mixed", "A mixed map", map_mixed),
     Exemplar( "map_nested", "A nested map", map_nested),
 
-    Exemplar( "map_string_keys", "A map with string keys", 
+    Exemplar( "map_string_keys", "A map with string keys",
               dict_of("first", 1, "second", 2, "third", 3)),
 
     Exemplar( "map_numeric_keys", "A map with numeric keys",


### PR DESCRIPTION
Captures some research and effort over the past weekend. Now tests pass without any warnings due to our own module.

There are still warnings, primarily due to use of `.*` and `./` operators from [Decimals](https://github.com/tinybike/Decimals.jl/blob/master/src/arithmetic.jl). I haven't done research to see if there's a different `Decimals` type library we could use. We could PR it again (as we did with 0.4), vendor it, whatever as a solution.

Some of the changes don't throw a warning yet but do with Julia 0.7 dev (i.e. use of `type` vs. `struct`). Worth some more review, testing, waiting possibly, but wanted to surface these changes for now.